### PR TITLE
feat: Implement Dual-Pane UI placeholders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,20 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.9.0",
+        "@reduxjs/toolkit": "^2.8.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "neo4j-driver": "^5.28.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-redux": "^9.2.0",
+        "react-router-dom": "^7.6.2",
         "winston": "^3.17.0",
         "zod": "^3.25.64"
       },
       "devDependencies": {
         "@types/node": "^24.0.1",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.5.2",
         "@vitest/ui": "^3.2.3",
         "c8": "^10.1.3",
@@ -1216,6 +1220,31 @@
         "@prisma/debug": "6.9.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz",
@@ -1494,6 +1523,16 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1604,6 +1643,12 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -1656,6 +1701,27 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -1669,6 +1735,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -2411,6 +2482,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3420,6 +3499,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4426,6 +4514,28 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4433,6 +4543,42 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/readable-stream": {
@@ -4448,6 +4594,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4456,6 +4615,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -4640,6 +4804,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5248,6 +5417,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/Delles/GraphHarness-Studio#readme",
   "devDependencies": {
     "@types/node": "^24.0.1",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.5.2",
     "@vitest/ui": "^3.2.3",
     "c8": "^10.1.3",
@@ -52,11 +53,14 @@
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",
+    "@reduxjs/toolkit": "^2.8.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "neo4j-driver": "^5.28.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-redux": "^9.2.0",
+    "react-router-dom": "^7.6.2",
     "winston": "^3.17.0",
     "zod": "^3.25.64"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,24 @@ app.whenReady().then(async () => {
   logger.info('Electron app is ready.');
   createWindow();
 
+  // --- Global Keyboard Shortcut Placeholders ---
+  // import { globalShortcut } from 'electron'; // Would be needed
+  // globalShortcut.register('CommandOrControl+S', () => {
+  //   // Example: Send IPC to renderer to trigger save action
+  //   // This assumes 'mainWindow' is accessible here or you have a way to get the focused window.
+  //   // For simplicity, let's assume 'mainWindow' is the one created by 'createWindow'.
+  //   // You might need to manage mainWindow instances more carefully in a multi-window app.
+  //   const focusedWindow = BrowserWindow.getFocusedWindow();
+  //   if (focusedWindow) {
+  //     // focusedWindow.webContents.send('global-shortcut-save');
+  //   }
+  //   logger.info('Placeholder: Global Ctrl+S pressed - would trigger save action in renderer.');
+  // });
+  // globalShortcut.register('CommandOrControl+O', () => {
+  //   logger.info('Placeholder: Global Ctrl+O pressed - would trigger open action.');
+  // });
+  // --- End Global Keyboard Shortcut Placeholders ---
+
   try {
     await graphService.getDriver(); // Initialize driver
     logger.info('Neo4j Driver initialized.');
@@ -83,3 +101,9 @@ app.on('window-all-closed', async function () {
     app.quit();
   }
 });
+
+// Placeholder for unregistering shortcuts
+// app.on('will-quit', () => {
+//   globalShortcut.unregisterAll();
+//   logger.info('Global shortcuts unregistered.');
+// });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import MainLayout from './components/MainLayout';
+
+// TODO: Future Scalability - Consider refactoring to a feature-based folder structure
+// as outlined in "docs/GraphHarness Studio – Technical Blueprint.md" (section 8.4).
+// For example: src/renderer/features/dualPane/ (containing MainLayout, SpreadsheetPane, CanvasPane)
+// and src/renderer/features/graphData/ (containing graphSlice and related store logic).
+// This would involve moving components and store slices into their respective feature folders.
+// For now, the current components/ and store/ structure is adequate for the initial placeholder phase.
 
 function App() {
   return (
-    <div>
-      <h1>Hello World from Electron, React, and Vite!</h1>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<MainLayout />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/renderer/components/CanvasPane.tsx
+++ b/src/renderer/components/CanvasPane.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useEffect, useState, useMemo, MouseEvent as ReactMouseEvent } from 'react'; // Added MouseEvent
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../store';
+import { updateNodePosition } from '../store/graphSlice';
+
+// --- React Flow Imports (Placeholder) ---
+// import ReactFlow, { Controls, Background, applyNodeChanges, applyEdgeChanges, Node, Edge, OnNodesChange, OnEdgesChange } from 'reactflow';
+// import 'reactflow/dist/style.css'; // Styles for React Flow
+
+// --- ELKjs Imports (Placeholder) ---
+// import ElkWorker from './elk-worker.js?worker'; // Placeholder for ELKjs worker for layout
+
+// --- Placeholder Types (React Flow would provide these) ---
+// interface FlowNode extends Node {
+//   // Custom properties can be added if needed
+// }
+// interface FlowEdge extends Edge {
+//   // Custom properties can be added if needed
+// }
+// type ElkNode = any; // Placeholder for ELK node structure
+// type ElkEdge = any; // Placeholder for ELK edge structure
+
+const CanvasPane: React.FC = () => {
+  const dispatch = useDispatch();
+  const graphData = useSelector((state: RootState) => state.graph);
+
+  // Placeholder state for React Flow nodes and edges
+  // const [nodes, setNodes] = useState<FlowNode[]>([]);
+  // const [edges, setEdges] = useState<FlowEdge[]>([]);
+  const [nodes, setNodes] = useState<any[]>([]);
+  const [edges, setEdges] = useState<any[]>([]);
+
+  // State for placeholder context menu
+  const [canvasMenuVisible, setCanvasMenuVisible] = useState(false);
+  const [canvasMenuPosition, setCanvasMenuPosition] = useState({ x: 0, y: 0 });
+  const [selectedCanvasItemId, setSelectedCanvasItemId] = useState<string | null>(null);
+
+  const handleShowCanvasContextMenu = (event: ReactMouseEvent<HTMLButtonElement>, itemId?: string) => {
+    event.preventDefault();
+    setCanvasMenuPosition({ x: event.clientX, y: event.clientY });
+    setCanvasMenuVisible(true);
+    setSelectedCanvasItemId(itemId || 'canvas'); // If no itemId, context is for the canvas itself
+    const type = itemId ? (graphData.nodes.find(n => n.id === itemId) ? 'Node' : 'Edge') : 'Canvas';
+    console.log(`Placeholder: Show context menu for ${type} ${itemId || ''} at (${event.clientX}, ${event.clientY})`);
+  };
+
+  const handleCanvasMenuAction = (action: string) => {
+    console.log(`Placeholder: Canvas context menu action "${action}" triggered for item ${selectedCanvasItemId}`);
+    setCanvasMenuVisible(false);
+    setSelectedCanvasItemId(null);
+  };
+
+
+  // Placeholder for onNodesChange callback
+  // const onNodesChange: OnNodesChange = useCallback(
+  //   (changes) => setNodes((nds) => applyNodeChanges(changes, nds)),
+  //   [setNodes]
+  // );
+
+  // Placeholder for onEdgesChange callback
+  // const onEdgesChange: OnEdgesChange = useCallback(
+  //   (changes) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+  //   [setEdges]
+  // );
+
+  // Effect to process data from store and prepare for React Flow (Placeholder)
+  useEffect(() => {
+    console.log('CanvasPane: Raw graph data from store:', graphData);
+    // Transformation logic to convert graphData.nodes and graphData.edges
+    // into React Flow compatible Node[] and Edge[] would go here.
+    // For now, just logging and setting placeholder data if needed.
+    // Example:
+    // const transformedNodes = graphData.nodes.map(n => ({ id: n.id, data: { label: n.label }, position: { x: 0, y: 0 } }));
+    // const transformedEdges = graphData.edges.map(e => ({ id: e.id, source: e.source, target: e.target }));
+    // setNodes(transformedNodes);
+    // setEdges(transformedEdges);
+
+    // If graphData.nodes are suitable directly (for placeholder purposes)
+    setNodes(graphData.nodes.map(n => ({ ...n, data: { label: n.label }, position: { x: Math.random() * 200, y: Math.random() * 200} }))); // Basic mapping for placeholder
+    setEdges(graphData.edges);
+
+  }, [graphData]);
+
+  // Placeholder for ELKjs layout logic
+  // const elkWorker = useMemo(() => new ElkWorker(), []);
+  // const onLayout = useCallback(async () => {
+  //   if (nodes.length === 0) return;
+  //   const elkNodes: ElkNode[] = nodes.map(node => ({
+  //     id: node.id,
+  //     width: 150, // Example width
+  //     height: 50, // Example height
+  //   }));
+  //   const elkEdges: ElkEdge[] = edges.map(edge => ({
+  //     id: edge.id,
+  //     sources: [edge.source],
+  //     targets: [edge.target],
+  //   }));
+  //   const graph = {
+  //     id: 'root',
+  //     layoutOptions: { 'elk.algorithm': 'layered' }, // Example ELK layout algorithm
+  //     children: elkNodes,
+  //     edges: elkEdges,
+  //   };
+  //   const layoutedGraph = await elkWorker.layout(graph);
+  //   setNodes(nodes.map(node => ({
+  //     ...node,
+  //     position: { x: layoutedGraph.children.find(n => n.id === node.id).x, y: layoutedGraph.children.find(n => n.id === node.id).y },
+  //   })));
+  // }, [nodes, edges, elkWorker, setNodes]);
+
+  // useEffect(() => {
+  //   onLayout();
+  // }, [nodes.length, edges.length, onLayout]); // Trigger layout when node/edge count changes
+
+  return (
+    // The main div for the canvas area. `role="application"` can be used for complex interactive areas.
+    // `aria-label` provides a description for screen readers.
+    <div
+      style={{ width: '100%', height: '500px', border: '1px solid black', position: 'relative' }}
+      role="application" // Or "img" if less interactive and more presentational
+      aria-label="Wiring harness canvas"
+      // TODO: Add keyboard interaction for canvas elements (e.g., tabbing to nodes if React Flow is not used)
+    >
+      {/* Placeholder for React Flow components */}
+      <p style={{ textAlign: 'center', paddingTop: '10px', paddingBottom: '10px' }}>
+        React Flow Canvas Area (Placeholder - `reactflow` dependency missing)
+      </p>
+      <button
+        onClick={() => {
+          if (graphData.nodes.length > 0) {
+            const randomNodeId = graphData.nodes[Math.floor(Math.random() * graphData.nodes.length)].id;
+            const newX = Math.floor(Math.random() * 400);
+            const newY = Math.floor(Math.random() * 400);
+            console.log(`Dispatching updateNodePosition for ${randomNodeId} to (${newX}, ${newY})`);
+            dispatch(updateNodePosition({ nodeId: randomNodeId, x: newX, y: newY }));
+          }
+        }}
+        style={{ margin: '10px', display: 'block' }}
+        aria-label="Simulate dragging a random node to a new position" // Descriptive label
+      >
+        Simulate Node Drag (Update Random Node Position)
+      </button>
+      <button
+        onClick={(e) => handleShowCanvasContextMenu(e)}
+        style={{ margin: '0 10px 10px 10px', display: 'block' }}
+        aria-label="Show canvas context menu" // Descriptive label
+        aria-haspopup="true" // Indicates it opens a menu
+        aria-expanded={canvasMenuVisible && selectedCanvasItemId === 'canvas'} // Reflects menu state for canvas context
+      >
+        Show Canvas Context Menu (Placeholder)
+      </button>
+      {/* <ReactFlow
+        // onPaneContextMenu={(event) => handleShowCanvasContextMenu(event)} // Example for real React Flow
+        // onNodeContextMenu={(event, node) => handleShowCanvasContextMenu(event, node.id)}
+        // onEdgeContextMenu={(event, edge) => handleShowCanvasContextMenu(event, edge.id)}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        fitView
+      >
+        <Controls />
+        <Background />
+      </ReactFlow> */}
+      <div style={{padding: '10px'}}>
+        <p>Nodes from store: {graphData.nodes.length}</p>
+        <p>Edges from store: {graphData.edges.length}</p>
+        {/* Displaying some node data as a simple list for verification */}
+        <ul>
+          {nodes.slice(0, 5).map(node => (
+            // Displaying label which might be updated by updateNodePosition
+            <li key={node.id}>{node.id} - {node.label || node.data?.label}</li>
+          ))}
+        </ul>
+      </div>
+      <p style={{ fontSize: '0.8em', padding: '10px' }}>
+        Note: Button above simulates a node drag, dispatching `updateNodePosition`.
+        The node's label in the list above should reflect this change as a proxy for actual position update.
+      </p>
+
+      {/* Placeholder Context Menu for Canvas */}
+      {/* TODO: Implement proper focus management when menu opens/closes.
+          When menu opens, focus should go to the first item.
+          When menu closes, focus should return to the trigger button.
+          Keyboard navigation (arrows, Escape) should work within the menu.
+      */}
+      {canvasMenuVisible && (
+        <div
+          role="menu" // ARIA role for context menu
+          aria-label={`Context menu for ${selectedCanvasItemId === 'canvas' ? 'canvas' : `item ${selectedCanvasItemId}`}`}
+          style={{
+            position: 'fixed', // Use fixed to position relative to viewport for simplicity
+            top: canvasMenuPosition.y, // Directly use clientX/Y for placeholder
+            left: canvasMenuPosition.x, // Directly use clientX/Y for placeholder
+            border: '1px solid #ccc',
+            backgroundColor: 'white',
+            padding: '10px',
+            zIndex: 1000,
+            boxShadow: '2px 2px 5px rgba(0,0,0,0.2)',
+          }}
+        >
+          {selectedCanvasItemId === 'canvas' ? (
+            <>
+              <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleCanvasMenuAction('Add Node')}>Add Node</button>
+              <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleCanvasMenuAction('Paste')}>Paste</button>
+            </>
+          ) : (
+            <>
+              <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleCanvasMenuAction('Edit Item')}>Edit Item ({selectedCanvasItemId})</button>
+              <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleCanvasMenuAction('Delete Item')}>Delete Item ({selectedCanvasItemId})</button>
+              {graphData.nodes.find(n => n.id === selectedCanvasItemId) && // Show only if it's a node
+                <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleCanvasMenuAction('Add Edge from Node')}>Add Edge from ({selectedCanvasItemId})</button>
+              }
+            </>
+          )}
+          <hr />
+          <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer', color: 'blue' }} onClick={() => setCanvasMenuVisible(false)}>Close Menu</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CanvasPane;

--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from 'react'; // Added useEffect
+import SpreadsheetPane from './SpreadsheetPane';
+import CanvasPane from './CanvasPane';
+
+const MainLayout: React.FC = () => {
+  // Placeholder for view-specific keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Example: Ctrl+Shift+K
+      if (event.ctrlKey && event.shiftKey && event.key === 'K') {
+        console.log('Placeholder: MainLayout - Ctrl+Shift+K pressed. Would trigger a view-specific action.');
+        // Prevent default browser behavior if necessary
+        // event.preventDefault();
+      }
+      // Example: Simple 'Escape' key press
+      if (event.key === 'Escape') {
+        console.log('Placeholder: MainLayout - Escape key pressed. Could be used to close modals or context menus.');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    console.log('MainLayout: Keydown listener added for placeholder shortcuts.');
+
+    // Cleanup function to remove the event listener
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      console.log('MainLayout: Keydown listener removed.');
+    };
+  }, []); // Empty dependency array means this effect runs once on mount and cleans up on unmount
+
+  return (
+    // Conceptual main wrapper for the application content
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }} role="application" aria-label="GraphHarness Studio Application">
+      {/* TODO: Define .visually-hidden CSS class globally (e.g., in index.css)
+          .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+          }
+      */}
+      {/* Header area - h1 is usually part of a header landmark */}
+      <header style={{ padding: '10px', borderBottom: '1px solid #ccc' }}>
+        <h1>Main Layout</h1>
+        {/* Add other header controls/nav here if any */}
+      </header>
+      {/* Main content area housing the two panes */}
+      <div style={{ display: 'flex', flexGrow: 1 }} role="main"> {/* Conceptual main content landmark */}
+        {/* Spreadsheet Pane Section - could be an aside or a main section depending on app structure */}
+        <section style={{ flex: 1, overflow: 'auto', padding: '10px' }} aria-labelledby="spreadsheet-pane-heading">
+          <h2 id="spreadsheet-pane-heading" className="visually-hidden">Spreadsheet Data View</h2> {/* Visually hidden heading for screen readers */}
+          <SpreadsheetPane />
+        </section>
+        {/* Canvas Pane Section - could be an aside or a main section */}
+        <section style={{ flex: 1, overflow: 'auto', padding: '10px' }} aria-labelledby="canvas-pane-heading">
+          <h2 id="canvas-pane-heading" className="visually-hidden">Canvas Visualization View</h2> {/* Visually hidden heading */}
+          <CanvasPane />
+        </section>
+      </div>
+      {/* Potential footer area */}
+      {/* <footer style={{ padding: '10px', borderTop: '1px solid #ccc' }}>
+        <p>Status bar or footer information</p>
+      </footer> */}
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/renderer/components/SpreadsheetPane.tsx
+++ b/src/renderer/components/SpreadsheetPane.tsx
@@ -1,0 +1,185 @@
+import React, { useState, MouseEvent as ReactMouseEvent } from 'react'; // Added MouseEvent
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../store';
+import { updateNodeData } from '../store/graphSlice';
+
+// import { useReactTable, getCoreRowModel, ColumnDef, flexRender } from '@tanstack/react-table';
+
+interface HarnessData {
+  id: string;
+  csa: number | string | null; // Cross-Sectional Area
+  colour: string | null;
+  optionCode?: string | null; // Made optional to match sample data
+  label?: string; // Added to match sample data
+}
+
+// Placeholder for TanStack Table Column Definitions
+// const columnHelper = createColumnHelper<HarnessData>();
+// const columns: ColumnDef<HarnessData>[] = [
+//   columnHelper.accessor('id', { header: () => <span>ID</span>, cell: info => info.getValue() }),
+//   columnHelper.accessor('csa', { header: () => <span>CSA</span>, cell: info => info.getValue() }),
+//   columnHelper.accessor('colour', { header: () => <span>Colour</span>, cell: info => info.getValue() }),
+//   columnHelper.accessor('optionCode', { header: () => <span>Option Code</span>, cell: info => info.getValue() }),
+// ];
+
+// Actual placeholder columns
+const placeholderColumns = [
+  { key: 'id', header: 'ID' },
+  { key: 'csa', header: 'CSA' },
+  { key: 'colour', header: 'Colour' },
+  { key: 'optionCode', header: 'Option Code' },
+  { key: 'label', header: 'Label' }, // Added to display more from sample data
+];
+
+const SpreadsheetPane: React.FC = () => {
+  const dispatch = useDispatch();
+  const data: HarnessData[] = useSelector((state: RootState) => state.graph.nodes);
+  const [editValueMap, setEditValueMap] = useState<{ [key: string]: string }>({}); // Changed to map
+
+  // State for placeholder context menu
+  const [tableMenuVisible, setTableMenuVisible] = useState(false);
+  const [tableMenuPosition, setTableMenuPosition] = useState({ x: 0, y: 0 });
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
+
+
+  const handleShowTableContextMenu = (event: ReactMouseEvent<HTMLButtonElement>, rowId: string) => {
+    event.preventDefault(); // Prevent default browser context menu
+    // In a real scenario, you might get these from the actual right-click event on a table row
+    setTableMenuPosition({ x: event.clientX, y: event.clientY });
+    setTableMenuVisible(true);
+    setSelectedRowId(rowId);
+    console.log(`Placeholder: Show context menu for row ${rowId} at (${event.clientX}, ${event.clientY})`);
+  };
+
+  const handleTableMenuAction = (action: string) => {
+    console.log(`Placeholder: Table context menu action "${action}" triggered for row ${selectedRowId}`);
+    setTableMenuVisible(false);
+    setSelectedRowId(null);
+  };
+
+  // Placeholder for TanStack Table instance
+  // const table = useReactTable({
+  //   data,
+  //   columns,
+  //   getCoreRowModel: getCoreRowModel(),
+  // });
+
+  return (
+    <div className="spreadsheet-pane">
+      {/* This is a placeholder table structure because @tanstack/react-table could not be installed. */}
+      {/* TODO: Add a caption element here for table summary if appropriate */}
+      <table aria-label="Harness Data Spreadsheet">
+        <thead>
+          <tr>
+            {placeholderColumns.map(col => (
+              <th key={col.key} scope="col" id={`col-${col.key}`}>{col.header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, rowIndex) => (
+            <tr key={row.id || rowIndex}>
+              {placeholderColumns.map(col => {
+                // Placeholder for an editable CSA cell
+                if (col.key === 'csa' && row.id) { // Ensure row.id exists for dispatch
+                  const nodeId = row.id; // Capture nodeId
+                  return (
+                    <td key={`${col.key}-${nodeId}`}>
+                      {String(row[col.key as keyof HarnessData] ?? '')}
+                      {/* Placeholder input for editing CSA */}
+                      <input
+                        type="text"
+                        placeholder="New CSA"
+                        style={{ marginLeft: '5px', width: '60px' }}
+                        aria-label={`Edit CSA for row ${nodeId}`} // Accessibility for input
+                        // aria-labelledby={`col-csa row-${nodeId}-label`} // More advanced for real tables
+                        value={editValueMap[nodeId] || ''}
+                        onChange={(e) => setEditValueMap({ ...editValueMap, [nodeId]: e.target.value })}
+                        onBlur={() => {
+                          const valueToDispatch = editValueMap[nodeId];
+                          if (valueToDispatch && valueToDispatch.trim() !== '') {
+                            console.log(`Dispatching updateNodeData for ${nodeId} with CSA: ${valueToDispatch}`);
+                            dispatch(updateNodeData({ nodeId, newData: { csa: valueToDispatch } }));
+                          }
+                        }}
+                      />
+                    </td>
+                  );
+                }
+                 // Add a button to trigger context menu for the 'id' column as an example
+                if (col.key === 'id' && row.id) {
+                  const nodeId = row.id;
+                  return (
+                    // In a real table, the cell itself might handle onContextMenu
+                    <td key={`${col.key}-${nodeId}`}>
+                      {String(row[col.key as keyof HarnessData] ?? '')}
+                      <button
+                        onClick={(e) => handleShowTableContextMenu(e, nodeId)}
+                        style={{ marginLeft: '5px', padding: '2px 5px', fontSize: '0.8em' }}
+                        aria-label={`Actions for row ${nodeId}`} // Accessibility for button
+                        aria-haspopup="true" // Indicates it opens a menu
+                        aria-expanded={tableMenuVisible && selectedRowId === nodeId} // State of the menu
+                      >
+                        ☰
+                      </button>
+                    </td>
+                  );
+                }
+                return (
+                  <td key={`${col.key}-${row.id || rowIndex}`}>
+                    {String(row[col.key as keyof HarnessData] ?? '')}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+              <td colSpan={placeholderColumns.length} style={{ textAlign: 'center' }}>
+                No data available or store not populated.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <p style={{ fontSize: '0.8em', marginTop: '10px' }}>
+        Note: CSA column has a placeholder input for demonstrating `updateNodeData` dispatch.
+        ID column has a button to simulate context menu.
+      </p>
+
+      {/* Placeholder Context Menu for Table */}
+      {/* Placeholder Context Menu for Table */}
+      {/* TODO: Implement proper focus management when menu opens/closes.
+          When menu opens, focus should go to the first item.
+          When menu closes, focus should return to the trigger button.
+          Keyboard navigation (arrows, Escape) should work within the menu.
+      */}
+      {tableMenuVisible && (
+        <div
+          role="menu" // ARIA role for context menu
+          aria-label={`Context menu for row ${selectedRowId}`}
+          style={{
+            position: 'absolute',
+            top: tableMenuPosition.y,
+            left: tableMenuPosition.x,
+            border: '1px solid #ccc',
+            backgroundColor: 'white',
+            padding: '10px',
+            zIndex: 1000,
+            boxShadow: '2px 2px 5px rgba(0,0,0,0.2)',
+          }}
+        >
+          {/* Using button for menu items for better accessibility (focusable, announces as button) */}
+          <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleTableMenuAction('Edit Row')}>Edit Row ({selectedRowId})</button>
+          <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleTableMenuAction('Delete Row')}>Delete Row ({selectedRowId})</button>
+          <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer' }} onClick={() => handleTableMenuAction('Copy Row Data')}>Copy Row Data ({selectedRowId})</button>
+          <hr />
+          <button role="menuitem" style={{ display: 'block', width: '100%', textAlign: 'left', padding: '5px', border: 'none', background: 'none', cursor: 'pointer', color: 'blue' }} onClick={() => setTableMenuVisible(false)}>Close Menu</button>
+        </div>
+      )}
+      {/* End of placeholder table structure */}
+    </div>
+  );
+};
+
+export default SpreadsheetPane;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css'; // Optional CSS
+import { Provider } from 'react-redux';
+import store from './store';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>
 );

--- a/src/renderer/store/graphSlice.ts
+++ b/src/renderer/store/graphSlice.ts
@@ -1,0 +1,83 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Node {
+  id: string;
+  label: string;
+  csa?: number | null;
+  colour?: string | null;
+  optionCode?: string | null;
+  // Add other node properties as needed
+}
+
+interface Edge {
+  id: string;
+  source: string;
+  target: string;
+  // Add other edge properties as needed
+}
+
+interface GraphState {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+const initialState: GraphState = {
+  nodes: [
+    { id: 'W001', label: 'Node 1', csa: 0.5, colour: 'RED', optionCode: 'OP01' },
+    { id: 'W002', label: 'Node 2', csa: 0.75, colour: 'BLUE', optionCode: 'OP02' },
+    { id: 'W003', label: 'Node 3', csa: 1.0, colour: 'GREEN', optionCode: 'OP03' },
+  ],
+  edges: [],
+};
+
+const graphSlice = createSlice({
+  name: 'graph',
+  initialState,
+  reducers: {
+    setInitialNodes: (state, action: PayloadAction<Node[]>) => {
+      state.nodes = action.payload;
+    },
+    setInitialEdges: (state, action: PayloadAction<Edge[]>) => {
+      state.edges = action.payload;
+    },
+    updateNodeData: (state, action: PayloadAction<{ nodeId: string; newData: Partial<Node> }>) => {
+      // TODO: IPC call to main process to persist this change (action.payload.nodeId, action.payload.newData)
+      const node = state.nodes.find(n => n.id === action.payload.nodeId);
+      if (node) {
+        Object.assign(node, action.payload.newData);
+      }
+    },
+    updateNodePosition: (state, action: PayloadAction<{ nodeId: string; x: number; y: number }>) => {
+      // TODO: IPC call to main process to persist this change (action.payload.nodeId, {x, y})
+      // This reducer assumes nodes have a 'position' property, which React Flow uses.
+      // If your Node interface doesn't have it, you might need to adjust or add it.
+      // For now, we'll assume 'label' can be updated as a proxy if 'position' is not directly on the Node model.
+      // This is a conceptual placeholder. In a real React Flow setup, node position is often managed by React Flow's
+      // internal state and then synced back if needed, or by directly updating a 'position' field in your Redux node.
+      const node = state.nodes.find(n => n.id === action.payload.nodeId);
+      if (node) {
+        // TODO: When React Flow is integrated, update the actual 'position' field on the Node object
+        // if the Node interface is extended with `position: { x: number, y: number }`.
+        // Example:
+        // if (!node.position) node.position = { x: 0, y: 0 };
+        // node.position.x = action.payload.x;
+        // node.position.y = action.payload.y;
+
+        // As a visible proxy for now, let's update the label to show the position change
+        node.label = `${node.label.split(' @')[0]} @ (${action.payload.x}, ${action.payload.y})`;
+        console.log(`Simulated position update for ${action.payload.nodeId}: (${action.payload.x}, ${action.payload.y})`);
+      }
+    },
+    // Potential updateEdgeData - can be added if edges become editable
+    // updateEdgeData: (state, action: PayloadAction<{ edgeId: string; newData: Partial<Edge> }>) => {
+    //   // TODO: IPC call to main process to persist this change
+    //   const edge = state.edges.find(e => e.id === action.payload.edgeId);
+    //   if (edge) {
+    //     Object.assign(edge, action.payload.newData);
+    //   }
+    // },
+  },
+});
+
+export const { setInitialNodes, setInitialEdges, updateNodeData, updateNodePosition } = graphSlice.actions;
+export default graphSlice.reducer;

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import graphReducer from './graphSlice';
+
+const store = configureStore({
+  reducer: {
+    graph: graphReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;


### PR DESCRIPTION
I've implemented the foundational structure for the Dual-Pane UI, including React Router, Redux store, and placeholder components for TanStack Table (SpreadsheetPane) and React-Flow (CanvasPane).

Key features implemented as placeholders:
- React Router and Redux store setup.
- SpreadsheetPane component with manual table rendering and placeholder for TanStack Table.
- CanvasPane component with basic display and placeholder for React-Flow and ELKjs layout.
- Two-way binding conceptual layer using Redux actions and placeholder dispatchers.
- Placeholder keyboard shortcuts and context menu skeletons.
- Basic accessibility (A11y) sweep with ARIA attributes and comments for future focus management.

NOTE: This implementation consists of placeholder code due to an inability to install npm packages (e.g., @tanstack/react-table, reactflow, elkjs) in the current environment. The application will not build or run correctly until these dependencies are manually installed and the placeholder code is fully integrated with these libraries. The code includes extensive comments detailing where these integrations are needed.